### PR TITLE
Answer boolean question with multiple answers.

### DIFF
--- a/S2SRL/processDataset/test.py
+++ b/S2SRL/processDataset/test.py
@@ -18,5 +18,34 @@ def test():
     temp_string = "%s::%s" %(answer, orig_response)
     print (temp_string)
 
+    line = '''symbolic_seq.append({"A1": ['Q910670', 'P47', 'Q20667921']})'''
+    key = line[line.find("{") + 1:line.find('}')].split(':')[0].replace('\"', '').strip()
+    print (key)
+    val = line[line.find("{") + 1: line.find('}')].split(':')[1].strip()
+    print (val)
+    val = val.replace('[', '')
+    print(val)
+    val = val.replace(']', '')
+    print(val)
+    val = val.replace("\'", "")
+    print(val)
+    val = val.strip()
+    print(val)
+    val =val.split(',')
+    print(val)
+
+    temp_list = list()
+    temp_dict = {"a":1}
+    if 'a' in temp_dict:
+        print ("a")
+    if '1' in temp_dict:
+        print("1")
+    temp_list.append(temp_dict)
+    temp_list.append(False)
+    print (temp_list)
+    for item in temp_list:
+        print (item.__class__)
+
+
 if __name__ == "__main__":
     test()

--- a/SymbolicExecutor/symbolics.py
+++ b/SymbolicExecutor/symbolics.py
@@ -6,7 +6,6 @@ try:
 except ImportError:
     from urllib.parse import urlencode
 
-from stack import Stack
 import pickle
 import requests
 def get_id(idx):
@@ -27,6 +26,7 @@ class Symbolics():
         self.seq = seq
         self.answer = {}
         self.temp_set = set([])
+        self.temp_bool_dict = {}
 
     def executor(self):
         for symbolic in self.seq:
@@ -34,14 +34,22 @@ class Symbolics():
             e = symbolic[key][0].strip()
             r = symbolic[key][1].strip()
             t = symbolic[key][2].strip()
+            # The execution result from A1 is in dict format.
             if ("A1" in symbolic):
-                self.answer = self.select(e, r, t)
+                temp_result = self.select(e, r, t)
+                self.answer = temp_result
+                self.temp_bool_dict = temp_result
                 self.print_answer()
             elif ("A2" in symbolic or "A16" in symbolic):
                 self.answer = self.select_all(e, r, t)
                 self.print_answer()
             elif ("A3" in symbolic):
-                self.answer = self.is_bool(e)
+                bool_temp_result = self.is_bool(e)
+                if '|BOOL_RESULT|' in self.answer:
+                    self.answer['|BOOL_RESULT|'].append(bool_temp_result)
+                else:
+                    temp = [bool_temp_result]
+                    self.answer.setdefault('|BOOL_RESULT|', temp)
                 self.print_answer()
             elif ("A4" in symbolic):
                 self.answer = self.arg_min()
@@ -163,8 +171,9 @@ class Symbolics():
     def is_bool(self, e):
         # print("A3: is_bool")
         if type(self.answer) == bool: return True
-        for key in self.answer:
-            if (self.answer[key] != None and e in self.answer[key]):
+        if self.temp_bool_dict == None: return False
+        for key in self.temp_bool_dict:
+            if (self.temp_bool_dict[key] != None and e in self.temp_bool_dict[key]):
                 return True
         return False
 
@@ -390,16 +399,3 @@ if __name__ == "__main__":
         val = result_dict[e]
         for v in val:
             print(v, kb.is_A(v))
-
-    AStack = Stack()
-    AStack.add("Mon")
-    AStack.add("Tue")
-    print(AStack.peek())
-    AStack.add("Wed")
-    AStack.add("Thu")
-    print(AStack.peek())
-    print(AStack.pop())
-    print(AStack.pop())
-    print(AStack.pop())
-    print(AStack.pop())
-    print(AStack.pop())

--- a/SymbolicExecutor/test_symbolics_d.py
+++ b/SymbolicExecutor/test_symbolics_d.py
@@ -1,16 +1,10 @@
 # -*- coding: utf-8 -*-
-# @Time    : 2019/05/03 20:21
+# @Time     : 2019/05/03 20:21
+# @Author   : Devin Hua
 import sys
 sys.path.append('..')
 import os
-import pickle
-import json
-import random
 import time
-from unittest import TestCase
-#from urllib import urlencode
-from urllib.parse import urlencode
-import requests
 from symbolics import Symbolics
 
 def test_folder(fpath):
@@ -36,8 +30,8 @@ def test_file(root, f):
     for line in qa_file:
         if line.startswith("symbolic_seq.append"):
             flag = 1
-            key = line[line.find("{") + 1:line.find('}')].split(':')[0].replace('\"', '').strip()
-            val = line[line.find("{") + 1:line.find('}')].split(':')[1].strip()
+            key = line[line.find("{")+1: line.find('}')].split(':')[0].replace('\"', '').strip()
+            val = line[line.find("{")+1: line.find('}')].split(':')[1].strip()
             val = val.replace('[', '').replace(']', '').replace("\'", "").split(',')
 
             sym_seq.append({key: val})
@@ -50,14 +44,19 @@ def test_file(root, f):
 
         if (line.startswith("-----------") and flag == 1):
             time_start = time.time()
+            # Actions execution.
             symbolic_exe = Symbolics(sym_seq)
             answer = symbolic_exe.executor()
 
+            # To judge the returned answers are in dict format or boolean format.
             if (type(answer) == dict):
                 temp = []
-                for key,value in answer.items():
-                    if(value):
-                        temp.extend(list(value))
+                if '|BOOL_RESULT|' in answer:
+                    temp.extend(answer['|BOOL_RESULT|'])
+                else:
+                    for key,value in answer.items():
+                        if(value):
+                            temp.extend(list(value))
                 answer = temp
 
             elif type(answer) == type([]) or type(answer) == type(set([])):

--- a/Utils/stack.py
+++ b/Utils/stack.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
-# @Time    : 2019/05/01 16:39
-# @Author  : DevinHua
+# @Time     : 2019/05/01 16:39
+# @Author   : Devin Hua
 
 class Stack:
 


### PR DESCRIPTION
1. 修正无法同时回答YES和NO的boolean问题
例如问题为：Does Together Again have Imthiaz Bakeer Markar and Walter Baldwin in its star cast ?
Q937543: Together Again, Q20983405: Imthiaz Bakeer Markar, Q3565682: Walter Baldwin, 
Q502895: common name
P161: cast member
操作序列设计为：
select(Q937543,P161,Q502895) -> A1: [' Q937543', ' P161', ' Q502895']
bool(Q20983405,in) -> A3: [' Q20983405', '', '']
bool(Q3565682,in) -> A3: [' Q3565682, '', '']
EOQ
为了执行这个操作序列，在symbolics类中增加了记录用于bool操作的select结果的字典：self.temp_bool_dict，并在self.answer字典中加入了key为‘|BOOL_RESULT|’的map，用于记录boolean结果。在test_symbolics_d文件中，当返回的answer为dict类型时，若key中有‘|BOOL_RESULT|’的键值对，则取这个的value为结果，返回一个list；否则还是遍历键值对得到entity list。这样返回的答案就可以为[False, True]这种列表。